### PR TITLE
add: link to replit run

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "html"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # 2048
 
 ![2048](https://oversea-ci.daocloud.io/api/badge/build/daocloud/dao-2048)
+[![run on repl.it](http://repl.it/badge/github/DaoCloud/dao-2048)](https://repl.it/github/DaoCloud/dao-2048)
 
 2048 是一款数字益智游戏，相同数字的方块合并在一起时会相加。每一回合都会多出一块写有 2 或者 4 的方块，当方块无法移动时游戏结束。玩家要想办法在这个小小的 16 个格子中凑出一块带有 **2048** （或更大）的方块。
 


### PR DESCRIPTION
i think it would be pretty cool to let people see how this code works (and edit / preview the program) right in their browser, without any manual downloads or installation. i'm thinking we can add a 'run on repl.it' button, which redirects to something like [this](https://repl.it/@eankeen/run-dao-2048):

![image](https://i.imgur.com/n7LZzeo.png)
