### PR TITLE
docs: fix bold emphasis syntax in README.md

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -44,4 +44,4 @@ helm upgrade --install dao-2048 dao-2048/dao-2048 --version $VERSION --set image
 
 ### Thanks
 
-This image is derived from the Docker Hub image **[alexwhen/docker-2048](https://registry.hub.docker.com/u/alexwhen/docker-2048/)**, thanks to the developer**[alexwhen] (https://github.com/alexwhen)** enthusiastic support. And thanks to gabrielecirulli's [2048] (https://github.com/gabrielecirulli/2048) project
+This image is derived from the Docker Hub image **[alexwhen/docker-2048](https://registry.hub.docker.com/u/alexwhen/docker-2048/)**, thanks to the developer **[alexwhen] (https://github.com/alexwhen)** enthusiastic support. And thanks to gabrielecirulli's [2048] (https://github.com/gabrielecirulli/2048) project

--- a/charts/README.md
+++ b/charts/README.md
@@ -44,4 +44,4 @@ helm upgrade --install dao-2048 dao-2048/dao-2048 --version $VERSION --set image
 
 ### Thanks
 
-This image is derived from the Docker Hub image **[alexwhen/docker-2048](https://registry.hub.docker.com/u/alexwhen/docker-2048/)**, thanks to the developer **[alexwhen] (https://github.com/alexwhen)** enthusiastic support. And thanks to gabrielecirulli's [2048] (https://github.com/gabrielecirulli/2048) project
+This image is derived from the Docker Hub image **[alexwhen/docker-2048](https://registry.hub.docker.com/u/alexwhen/docker-2048/)**, thanks to the developer **[alexwhen](https://github.com/alexwhen)** enthusiastic support. And thanks to gabrielecirulli's [2048](https://github.com/gabrielecirulli/2048) project


### PR DESCRIPTION
As title.

There is a missing space between emphasis syntax and normal texts which results in bad parsing and rendering output.